### PR TITLE
change to work without additional dependency for notifications and use notify-send

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -6,7 +6,7 @@ The **notifications** script for Irssi uses desktop notifications to inform the 
 
 ## Installation
 
-**IMPORTANT:** A working installation of the **Gtk2::Notify** module for Perl is required for this script to function. In Fedora, this module is provided by the *perl-Gtk2-Notify* package; in Debian and Ubuntu, the package is named *libgtk2-notify-perl*.
+`notify-send` binary should be exists in your system.
 
 Irssi looks for additional scrips in the in the **~/.irssi/scripts/** directory. To make sure that this directory exists, type the following at a shell prompt:
 

--- a/notifications.pl
+++ b/notifications.pl
@@ -16,14 +16,13 @@
 use strict;
 use warnings;
 use Encode;
-use Gtk2::Notify -init, "Irssi";
 use Irssi;
 
 # The character encoding of the Irssi client:
 use constant ENCODING => "UTF-8";
 
 # General script information:
-our $VERSION  = '0.9.3';
+our $VERSION  = '0.9.4';
 our %IRSSI    = (
   name        => 'notifications',
   description => 'Notify the user about incoming messages.',
@@ -43,7 +42,7 @@ sub display_notification {
   $body = decode(ENCODING, $body);
 
   # Display the notification:
-  Gtk2::Notify->new($summary, $body, "im-message-new")->show();
+  system('/usr/bin/notify-send', $summary, $body);
 }
 
 # Handle incoming public messages:


### PR DESCRIPTION
Hi @jhradilek thanks for the package. I've just opened Irssi for myself and I'm also a bit conservative in terms of packages installed in my system. 

Please take a look at this PR. It users `notify-send` binary which is usually installed on linux distros. 
In some sense it not as crossplatform as the current solution, so reject it if you wish. 

P.S.
I see the script is not maintained, but the it's very useful. Do you still use it?